### PR TITLE
Fetch API - error handing

### DIFF
--- a/serverless/bridge-monitor/Health/index.ts
+++ b/serverless/bridge-monitor/Health/index.ts
@@ -14,11 +14,17 @@ interface healthStatus {
 
 const timerTrigger: AzureFunction = async function (_: Context, __: any): Promise<void> {
 
-    const healthStatus: healthStatus = await(await fetch(bridgeUrl).catch(
-        (_) => {
-            throw new Error("Failed to get health status - is service running?");
-        }
-    )).json();
+    const healthStatus: healthStatus = await(
+        await fetch(bridgeUrl)
+            .then((response) => {
+                if (response.ok) {
+                    return response;
+                }
+                throw new Error(`Network response was not ok. Status: ${response.status}`);
+            }).catch((_) => {
+                throw new Error("Failed to get health status - is service running?");
+            })
+    ).json();
 
     if (healthStatus.overall !== "pass")
     {

--- a/serverless/bridge-tasks/PriceApiFetch/index.ts
+++ b/serverless/bridge-tasks/PriceApiFetch/index.ts
@@ -38,10 +38,22 @@ class ConstantPriceOracle implements PriceOracle {
 
 class BinancePriceOracle implements PriceOracle {
     async getPrices(symbols: string[]): Promise<PriceResult[]> {
-
-        const priceBTC = await(await fetch(binanceUrl + new URLSearchParams({
-            symbol: "BTCUSDT",
-        }))).json();
+        let priceBTC;
+        try {
+            priceBTC = await(
+                await fetch(binanceUrl + new URLSearchParams({
+                    symbol: "BTCUSDT",
+                })).then((response) => {
+                    if (response.ok) {
+                        return response;
+                    }
+                    throw new Error(`Network response was not ok. Status: ${response.status}`);
+                })
+            ).json();
+        } catch(err) {
+            throw new Error(`Binance oracle failed to fetch price BTC: ${err}`);
+        }
+        
 
         return Promise.all<PriceResult>(
             symbols.map(async (symbol): Promise<PriceResult> => {
@@ -54,14 +66,21 @@ class BinancePriceOracle implements PriceOracle {
                     return {symbol: "BTC", price: priceBTC.price};
                 }
 
-                const priceRelative = await fetch(binanceUrl + new URLSearchParams({
-                    symbol: `${symbol}BTC`,
-                })).catch(
-                    (err) => {
-                        //console.log(`symbol doesn't exist: ${err}`);
-                        return undefined;
+                let priceRelative;
+                try {
+                    priceRelative = await fetch(binanceUrl + new URLSearchParams({
+                        symbol: `${symbol}BTC`,
+                    }));
+
+                    if (!priceRelative.ok) {
+                        throw new Error(`Network response was not ok. Status: ${priceRelative.status}`);
                     }
-                );
+                } catch {
+                    return {
+                        symbol,
+                        price: undefined
+                    };
+                }
 
                 const resultRelative = await priceRelative.json();
 
@@ -134,18 +153,23 @@ class CoinGeckoOracle implements PriceOracle {
                     };
                 }
 
-                const priceRelative = await fetch(coinGeckoUrl + new URLSearchParams({
-                    ids: coinGeckoID,
-                    // eslint-disable-next-line @typescript-eslint/camelcase
-                    vs_currencies: "USD"
-                })).catch(
-                    (_) => {
-                        return {
-                            symbol,
-                            price: undefined
-                        };
+                let priceRelative;
+                try {
+                    priceRelative = await fetch(coinGeckoUrl + new URLSearchParams({
+                        ids: coinGeckoID,
+                        // eslint-disable-next-line @typescript-eslint/camelcase
+                        vs_currencies: "USD"
+                    }));
+
+                    if (!priceRelative.ok) {
+                        throw new Error(`Network response was not ok. Status: ${priceRelative.status}`);
                     }
-                );
+                } catch {
+                    return {
+                        symbol,
+                        price: undefined
+                    };
+                }
 
                 const asJson = await priceRelative.json();
                 try {

--- a/serverless/bridge-tasks/TotalLockedFetch/index.ts
+++ b/serverless/bridge-tasks/TotalLockedFetch/index.ts
@@ -149,7 +149,12 @@ const ethPrice = async (): Promise<string> => {
         ids: "ethereum",
         // eslint-disable-next-line @typescript-eslint/camelcase
         vs_currencies: "USD"
-    }));
+    })).then((response) => {
+        if (response.ok) {
+            return response;
+        }
+        throw new Error(`Network response was not ok. Status: ${response.status}`);
+    });
     return (await price.json())["ethereum"].usd
 };
 

--- a/serverless/secret-api-datahub/ProxyLcdRequest/index.ts
+++ b/serverless/secret-api-datahub/ProxyLcdRequest/index.ts
@@ -22,12 +22,19 @@ const httpTrigger: AzureFunction = async function (context: Context, req: HttpRe
         body: JSON.stringify(req.body),
     });
 
-    const respBody = await response.text();
+    if (response.ok) {
+        const respBody = await response.text();
 
-    context.res = {
-        status: response.status,
-        body: respBody,
-    };
+        context.res = {
+            status: response.status,
+            body: respBody,
+        };
+    } else {
+        context.res = {
+            status: 500,
+            body: "Something went wrong"
+        };
+    }
 
 };
 

--- a/serverless/secret-api-enigma/ProxyLcdRequest/index.ts
+++ b/serverless/secret-api-enigma/ProxyLcdRequest/index.ts
@@ -37,12 +37,19 @@ const httpTrigger: AzureFunction = async function (context: Context, req: HttpRe
         agent: httpsAgent
     });
 
-    const respBody = await response.text();
+    if (response.ok) {
+        const respBody = await response.text();
 
-    context.res = {
-        status: response.status,
-        body: respBody
-    };
+        context.res = {
+            status: response.status,
+            body: respBody
+        };
+    } else {
+        context.res = {
+            status: 500,
+            body: "Something went wrong"
+        };
+    }
 
 };
 

--- a/serverless/secretswap-tasks/FetchPriceSecretSwap/index.ts
+++ b/serverless/secretswap-tasks/FetchPriceSecretSwap/index.ts
@@ -34,7 +34,12 @@ const getScrtPrice = async (): Promise<number> => {
         ids: "secret",
         // eslint-disable-next-line @typescript-eslint/camelcase
         vs_currencies: "USD"
-    })).catch(
+    })).then((response) => {
+        if (response.ok) {
+            return response;
+        }
+        throw new Error(`Network response was not ok. Status: ${response.status}`);
+    }).catch(
         (_) => {
             throw new Error("Failed to parse response for secret");
         }


### PR DESCRIPTION
Improved error handling for fetch API. by [checking that the fetch was successful](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#checking_that_the_fetch_was_successful) ([`response.ok`](https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)).

In the future, this can be implemented in a more reusable way by creating a single helper that is shared by all azure functions. I have not done it this way because:
- I don't have access to azure functions
- it may require additional changes in the configuration of azure functions
- requires thorough testing if everything works correctly after the change (deployment + code)

Some links that might be useful in the future if you decide to implement it this way:
- [fetch helper](https://stackoverflow.com/a/66713599)
- [code sharing](https://github.com/Azure/Azure-Functions/issues/92#issuecomment-357418722)
- [watchDirectories](https://stackoverflow.com/a/40684396)

**Disclaimer:** 
These code changes related to serverless (azure functions), which I have not been able to run and test (I don't have access to). So before the merge, please make some tests for related features to make sure that everything works fine.